### PR TITLE
NFT購入ロジックの追加

### DIFF
--- a/components/page/item-detail/item-detail.container.tsx
+++ b/components/page/item-detail/item-detail.container.tsx
@@ -25,6 +25,7 @@ export const ItemDetail = () => {
     const meta = await axios.get(tokenUri);
     const priceInEther = ethers.utils.formatUnits(token.price.toString(), 'ether');
     const item = {
+      itemId: parseInt(token.itemId),
       tokenId: parseInt(tokenId),
       priceInEther,
       seller: token.seller,

--- a/components/page/item-detail/item-detail.tsx
+++ b/components/page/item-detail/item-detail.tsx
@@ -2,13 +2,14 @@ import { Box, HStack, Stack, Text, VStack, Divider, Button, Tooltip } from '@cha
 import { MdOutlineDescription, MdOutlineAccountBalanceWallet } from 'react-icons/md';
 import { SiEthereum } from 'react-icons/si';
 import { INFT } from '../nft-list/types';
+import { buyMarketItem } from '../../../utils/contractHelper';
+import { ethers } from 'ethers';
 
 type Props = {
   nft: INFT;
 };
 
-export const ItemDetailComponent = ({ nft }) => {
-  console.log(nft);
+export const ItemDetailComponent: React.FC<Props> = ({ nft }) => {
   if (!nft) {
     return <div>Loading...</div>;
   }
@@ -24,11 +25,21 @@ export const ItemDetailComponent = ({ nft }) => {
       </Stack>
 
       <VStack alignItems='start'>
-        <Text fontSize='4xl' fontWeight='bold' mb='6'>
+        <Text fontSize='4xl' fontWeight='bold'>
           {nft.name}
         </Text>
 
-        <Stack boxShadow='lg' m='4' borderRadius='md' maxW='lg'>
+        {nft.owner != ethers.constants.AddressZero ? (
+          <Text fontSize='sm' color={'gray.600'}>
+            Owned by {nft.owner}
+          </Text>
+        ) : (
+          <Text fontSize='sm' color={'gray.600'}>
+            On Sale
+          </Text>
+        )}
+
+        <Stack boxShadow='lg' borderRadius='md' maxW='lg'>
           <Stack p='4' pb='0' direction='row' alignItems='center'>
             <MdOutlineDescription />
             <Text fontWeight='semibold'>Description</Text>
@@ -62,19 +73,22 @@ export const ItemDetailComponent = ({ nft }) => {
               {nft.priceInEther}
             </Text>
           </HStack>
-          <HStack p='4' pt='0'>
-            <Button
-              gap='2'
-              bg={'white'}
-              border={'2px solid'}
-              borderColor={'brand.primary'}
-              color={'brand.primary'}
-              _hover={{ bg: 'brand.primary', color: 'white' }}
-            >
-              <MdOutlineAccountBalanceWallet />
-              Buy Now
-            </Button>
-          </HStack>
+          {nft.owner == ethers.constants.AddressZero && (
+            <HStack p='4' pt='0'>
+              <Button
+                onClick={() => buyMarketItem(nft.priceInEther, nft.itemId)}
+                gap='2'
+                bg={'white'}
+                border={'2px solid'}
+                borderColor={'brand.primary'}
+                color={'brand.primary'}
+                _hover={{ bg: 'brand.primary', color: 'white' }}
+              >
+                <MdOutlineAccountBalanceWallet />
+                Buy Now
+              </Button>
+            </HStack>
+          )}
         </Stack>
       </VStack>
     </HStack>

--- a/components/page/nft-item/nft-item.tsx
+++ b/components/page/nft-item/nft-item.tsx
@@ -1,7 +1,9 @@
-import { Box, useColorModeValue, Flex, Button, Divider, HStack } from '@chakra-ui/react';
+import { Box, useColorModeValue, Flex, Button, Divider, HStack, Text } from '@chakra-ui/react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { INFT } from '../nft-list/types';
+import { buyMarketItem } from '../../../utils/contractHelper';
+import { ethers } from 'ethers';
 
 type Props = {
   nft: INFT;
@@ -49,9 +51,15 @@ export const NFTItemComponent: React.FC<Props> = ({ nft }) => {
         <Divider />
 
         <Flex justifyContent='end' px='6' py='3'>
-          <Button borderRadius='30px' size='xs'>
-            Buy Now
-          </Button>
+          {nft.owner == ethers.constants.AddressZero ? (
+            <Button onClick={() => buyMarketItem(nft.priceInEther, nft.itemId)} borderRadius='30px' size='xs'>
+              Buy Now
+            </Button>
+          ) : (
+            <Text fontSize='sm' color={'gray.600'}>
+              Owned Item
+            </Text>
+          )}
         </Flex>
       </Box>
     </Flex>

--- a/components/page/nft-list/nft-list.container.tsx
+++ b/components/page/nft-list/nft-list.container.tsx
@@ -25,6 +25,7 @@ export const NFTList = () => {
         const meta = await axios.get(tokenUri);
         const priceInEther = ethers.utils.formatUnits(i.price.toString(), 'ether');
         const item = {
+          itemId: i.itemId.toNumber(),
           tokenId: i.tokenId.toNumber(),
           priceInEther,
           seller: i.seller,
@@ -36,7 +37,6 @@ export const NFTList = () => {
         return item;
       }),
     );
-
     setNfts(items);
   }, []);
 

--- a/components/page/nft-list/types.ts
+++ b/components/page/nft-list/types.ts
@@ -1,4 +1,5 @@
 export interface INFT {
+  itemId: number;
   tokenId: number;
   priceInEther: string;
   seller: string;

--- a/utils/contractHelper.ts
+++ b/utils/contractHelper.ts
@@ -1,0 +1,22 @@
+import { ethers } from 'ethers';
+import Web3Modal from 'web3modal';
+
+import { nftaddress, nftmarketaddress } from '../config';
+import Market from '..//artifacts/contracts/Market.sol/Market.json';
+import NFT from '..//artifacts/contracts/NFT.sol/NFT.json';
+import { JsonRpcProvider } from '@ethersproject/providers';
+
+export const buyMarketItem = async (price: string, itemId: number) => {
+  try {
+    const web3Modal = new Web3Modal();
+    const connection = await web3Modal.connect();
+    const provider = new ethers.providers.Web3Provider(connection);
+    const signer = provider.getSigner();
+    const marketContract = new ethers.Contract(nftmarketaddress, Market.abi, signer);
+    const priceInWei = ethers.utils.parseUnits(price, 'ether');
+    const transaction = await marketContract.buyNFT(nftaddress, itemId, { value: priceInWei });
+    await transaction.wait();
+  } catch (err) {
+    console.log('Failed to buy, ', err.message);
+  }
+}


### PR DESCRIPTION
### 内容
・NFT購入用のヘルパー関数を作成（後々別の関数もヘルパー化）
・作品詳細画面、作品一覧画面でそれぞれ購入用関数を叩けるように設定
・itemIdを取得するようにする